### PR TITLE
Fix subtle variable linespace bug in `Reduce`

### DIFF
--- a/TextFrames.Mod
+++ b/TextFrames.Mod
@@ -220,7 +220,7 @@ MODULE TextFrames; (*JG 8.10.90 / NW 10.5.2013 / 11.2.2017*)
   BEGIN F.H := F.H + F.Y - newY; F.Y := newY;
     botY := F.Y + F.bot + dsr;
     L := F.trailer; curY := F.Y + F.H - F.top - asr;
-    WHILE (L.next # F.trailer) & (curY >= botY) DO
+    WHILE (L.next # F.trailer) & (curY - L.next.lsp >= botY) DO
       L := L.next; curY := curY - L.lsp
     END;
     L.next := F.trailer;


### PR DESCRIPTION
When reducing a viewer's size, the previous code did not always clear out partially visible lines.

This results in a weird bug. When you open e.g. `System.Directory` and the new viewer covers half of a line of `System.Tool`, the half line sometimes stays there (which may be unnoticed as there is enough space for that line). When you decide next to close that viewer again (without interacting with System.Tool first), the half line gets XORed over with the same line, resulting in only the lower half of the line being visible. When you then open another `System.Directory` and close it again, the line reappears fully again (as it is not cleared by `Reduce` again, but that does not matter as it is already empty. XORing over that empty space results in the whole line being visible again).

Yes, I introduced this bug myself in 1b14c9b61d7ccc59ae86888679b80a10ceb0fb39, and it did not appear during my initial testing. But it appeared again and again for no particular reason (and its self-healing puzzled me the most), so I did not find time to track it down and finally fix it.